### PR TITLE
fix:TOP10不會顯示當前使用者

### DIFF
--- a/services/followship-service.js
+++ b/services/followship-service.js
@@ -38,7 +38,10 @@ const followshipServices = {
   followshipTop10: (req, cb) => {
     User.findAll({
       group: 'User.id',
-      where: { role: 'user' },
+      where: {
+        role: 'user',
+        id: { [sequelize.Op.not]: getUser(req).dataValues.id }
+      },
       attributes: [
         'id', 'account', 'name', 'avatar', 'introduction',
         [sequelize.literal('(SELECT COUNT(DISTINCT id) FROM Followships WHERE followingId = User.id)'),


### PR DESCRIPTION
修改TOP10的API ，回傳資料不會顯示當前使用者
為了滿足Acceptance Criteria條件
當初再寫的時候沒有注意到，抱歉