### PR TITLE
feat: add delete association to like(當推文刪除時，使用者喜歡該推文的紀錄也會刪除)

### DIFF
--- a/migrations/20220302054749-add-delete-associtation-to-like.js
+++ b/migrations/20220302054749-add-delete-associtation-to-like.js
@@ -1,0 +1,20 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addConstraint('Likes', {
+      fields: ['TweetId'],
+      type: 'foreign key',
+      name: 'delete-association',
+      references: {
+        table: 'Tweets',
+        field: 'id'
+      },
+      onDelete: 'cascade'
+    })
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeConstraint('Likes', 'delete-association')
+  }
+}


### PR DESCRIPTION
因應前端要求：在刪除推文時，連同使用者喜歡該推文的紀錄一並刪除，因此寫了一個migration 檔，在likes 資料表的外鍵 tweetId 增加一個限制，如果該推文被刪除，該推文的喜歡紀錄也會被刪除